### PR TITLE
fixed it to make it work with 2.6.1

### DIFF
--- a/configs/rabbitmq/rabbitmq.config.shovel
+++ b/configs/rabbitmq/rabbitmq.config.shovel
@@ -3,7 +3,7 @@
              ]},
     {rabbit, [{vm_memory_high_watermark, 0.4}
              ]},
-    {rabbit_shovel,
+    {rabbitmq_shovel,
        [{shovels,
          [{avocado_order_shovel,
            [{sources,      [{broker, "amqp://guest:guest@localhost:5675/"},


### PR DESCRIPTION
I spent a little time wrestling with making this work until I read the docs and discovered it should be rabbitmq_shovel, not rabbit_shovel.
