### PR TITLE
Making Chapter 3 php examples work using Debian packages

### DIFF
--- a/php/chapter-3/log-listeners-debian.php
+++ b/php/chapter-3/log-listeners-debian.php
@@ -1,0 +1,51 @@
+<?php
+
+require_once('../config/config-debian.php');
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
+$ch = $conn->channel();
+
+list($errors_queue, , ) = $ch->queue_declare();
+list($warnings_queue, , ) = $ch->queue_declare();
+list($info_queue, , ) = $ch->queue_declare();
+
+$exchange = 'amq.rabbitmq.log';
+
+$ch->queue_bind($errors_queue, $exchange, "error");
+$ch->queue_bind($warnings_queue, $exchange, "warning");
+$ch->queue_bind($info_queue, $exchange, "info");
+
+$error_callback = function($msg) {
+    echo 'error: ', $msg->body, "\n";
+    $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+};
+
+$warning_callback = function($msg) {
+    echo 'warning: ', $msg->body, "\n";
+    $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+};
+
+$info_callback = function($msg) {
+    echo 'info: ', $msg->body, "\n";
+    $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+};
+
+$ch->basic_consume($errors_queue, "", false,
+                   false, false, false,
+                   $error_callback);
+
+$ch->basic_consume($warnings_queue, "", false,
+                   false, false, false,
+                   $warning_callback);
+
+$ch->basic_consume($info_queue, "", false,
+                   false, false, false,
+                   $info_callback);
+
+while(count($ch->callbacks)) {
+    $ch->wait();
+}
+
+?>

--- a/php/chapter-3/rabbitmqctl-examples-debian.php
+++ b/php/chapter-3/rabbitmqctl-examples-debian.php
@@ -1,0 +1,32 @@
+<?php
+
+// This version works on Debian when using the php-amqplib Debian package
+
+spl_autoload_register(
+    function ($class) {
+        include str_replace("\\", "/", $class) . '.php';
+    }
+);
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+define('HOST', 'localhost');
+define('PORT', 5672);
+define('USER', 'guest');
+define('PASS', 'guest');
+define('VHOST', '/');
+
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
+//$conn = new AMQPConnection(HOST, PORT, USER, PASS);
+$channel = $conn->channel();
+
+$channel->exchange_declare('logs-exchange', 'topic', false, true, false);
+
+$channel->queue_declare('msg-inbox-errors', false, true, false, false);
+$channel->queue_declare('msg-inbox-logs', false, true, false, false);
+$channel->queue_declare('all-logs', false, true, false, false);
+
+$channel->queue_bind('msg-inbox-errors', 'logs-exchange', 'error.msg-inbox');
+$channel->queue_bind('msg-inbox-logs', 'logs-exchange', '*.msg-inbox');
+
+?>

--- a/php/chapter-3/rabbitmqctl-examples-debian.php
+++ b/php/chapter-3/rabbitmqctl-examples-debian.php
@@ -17,7 +17,6 @@ define('PASS', 'guest');
 define('VHOST', '/');
 
 $conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
-//$conn = new AMQPConnection(HOST, PORT, USER, PASS);
 $channel = $conn->channel();
 
 $channel->exchange_declare('logs-exchange', 'topic', false, true, false);

--- a/php/config/config-debian.php
+++ b/php/config/config-debian.php
@@ -1,0 +1,23 @@
+<?php
+###############################################
+# RabbitMQ in Action
+#
+# Requires: php-amqplib
+#
+# Author: Alvaro Videla
+# (C)2010
+###############################################
+
+spl_autoload_register(
+    function ($class) {
+        include str_replace("\\", "/", $class) . '.php';
+    }
+);
+
+define('HOST', 'localhost');
+define('PORT', 5672);
+define('USER', 'guest');
+define('PASS', 'guest');
+define('VHOST', '/');
+
+?>


### PR DESCRIPTION
Added another example that assumes the user installed php and php-amqplib from apt.  This example doesn't depend on composer like the stock php-amqplib and book assumes.
